### PR TITLE
Consistant use of VK constants

### DIFF
--- a/src/main/java/de/codesourcery/swing/autocomplete/AutoCompleteBehaviour.java
+++ b/src/main/java/de/codesourcery/swing/autocomplete/AutoCompleteBehaviour.java
@@ -271,10 +271,10 @@ public class AutoCompleteBehaviour<T>
 
                 switch ( e.getKeyChar() ) 
                 {
-                    case ' ':
-                    case 0x10:
-                    case 0x0a:
-                    case 0x1b: // ESC
+                    case KeyEvent.VK_SPACE:
+                    case KeyEvent.VK_SHIFT:
+                    case 0x0a: // LF ?
+                    case KeyEvent.VK_ESCAPE:
                         e.consume();
                         eventHandled = true;                            
                         break;


### PR DESCRIPTION
I couldn't find `0x0a` in `KeyEvent`, on the ASCII chart it's LF (line feed).

Maybe this is a bug and you are not catching the key you think you are catching!